### PR TITLE
Fixed socket error handling.

### DIFF
--- a/src/HAProxy/Executor.php
+++ b/src/HAProxy/Executor.php
@@ -107,16 +107,16 @@ class Executor {
 	
 	protected function openSocket() {
 		if (strpos($this->connection_string, ':')) {
-			// TCP Socket
-			$this->socket = stream_socket_client('tcp://'.$this->connection_string, $errorno, $errorstr);
+			// TCP Socket, @ to hide warnings.
+			$this->socket = @stream_socket_client('tcp://'.$this->connection_string, $errorno, $errorstr);
 		} else if (@filetype(realpath($this->connection_string)) == 'socket') {
-			// UNIX Domain Socket
-			$this->socket = stream_socket_client('unix://'.realpath($this->connection_string), $errorno, $errorstr);
+			// UNIX Domain Socket, @ to hide warnings.
+			$this->socket = @stream_socket_client('unix://'.realpath($this->connection_string), $errorno, $errorstr);
 		} else {
 			throw new Exception("Could not open a connection to \"$this->connection_string\": the connection string is invalid");
 		}
 		if (!$this->socket) {
-			throw new Exception("Could not open a connection to \"$this->connection_string\": $errstr ($errno)");
+			throw new Exception("Could not open a connection to \"$this->connection_string\": $errorstr ($errorno)");
 		}
 	}
 	


### PR DESCRIPTION
Hide warnings generated by stream_socket_client() when the socket connection fails (why do they keep such odd stuff in PHP anyway?) and use correct variables to display errors.

FYI: I was running PHP 7.0 when I came across this...