### PR TITLE
Add method to send a command / action to HAProxy Backend e.g. drain, …

### DIFF
--- a/src/HAProxy/Command/SendCommand.php
+++ b/src/HAProxy/Command/SendCommand.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * HAProxyAPI is a PHP API to access/administrate HAProxy via
+ * UNIX Sockets, TCP Sockets and/or the HAProxy HTTP interface.
+ *
+ * HAProxyAPI was written by Steve Kamerman, 2016 and is distributed
+ * via GitHub at https://github.com/kamermans/HAProxyAPI
+ *
+ *  @author Jan Mara
+ *  @copyright Steve Kamerman, 2016
+ *  @license GNU GPLv3
+ *
+ * This file is part of HAProxyAPI.
+ *
+ * HAProxyAPI is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HAProxyAPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HAProxyAPI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace HAProxy\Command;
+
+class SendCommand extends EnableServer {
+  public function __construct($backend, $server, $action) {
+    $this->backend = $backend;
+    $this->server = $server;
+    $this->action = $action;
+  }
+}


### PR DESCRIPTION
Hi,

the Disable/EnableServer method implements the "enable / disable" action which has been replaced by (ready, drain, maint) since the release of 1.5.0 stable.

This method lets the user decide which command/action should be send. Hope you'll find it usefull too :)

Cheers,
Jan